### PR TITLE
Fix factorial overflow for large matrices

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: deco
 Type: Package
 Title: Decomposing Heterogeneous Cohorts using Omic Data Profiling
-Version: 1.9.1
+Version: 1.9.2
 Date: 2019-03-27
 Author: Francisco Jose Campos-Laborie, Jose Manuel Sanchez-Santos and Javier De
     Las Rivas. Bioinformatics and Functional Genomics Group. Cancer Research Center

--- a/R/additionalFunctions.R
+++ b/R/additionalFunctions.R
@@ -235,8 +235,8 @@ subsamplingProb <- function(x, iter, n1, n2 = 0) {
         
         m <- p1o * p2o
         
-        r1 <- factorial(n1)/(factorial(x) * factorial(n1 - x))
-        r2 <- factorial(n2)/(factorial(x) * factorial(n2 - x))
+        r1 <- choose(n1, x)
+        r2 <- choose(n2, x)
         
         m1 <- m * p2o * iter
         m2 <- m * p1o * iter
@@ -246,7 +246,7 @@ subsamplingProb <- function(x, iter, n1, n2 = 0) {
         all <- r1 * r2
     } else {
         p1o <- x/n1
-        r1 <- factorial(n1)/(factorial(x) * factorial(n1 - x))
+        r1 <- choose(n1, x)
         m <- 0
         all <- r1
     }


### PR DESCRIPTION
When running DECO on a large dataset the `factorial(n1)` becomes `Inf` making it impossible to calculate `subsamplingProb`. This PR replaces the combinations calculation with `choose()`. @fjcamlab please consider this fix.